### PR TITLE
fix: re-register MCP tools for per-agent workspace registries

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,11 +1,58 @@
 import { parseConfig } from "./config.js";
 import { McpClientPool } from "./mcp-client.js";
 
+interface ToolCacheEntry {
+  toolName: string;
+  serverName: string;
+  originalName: string;
+  description: string;
+  parameters: unknown;
+}
+
+// Module-level globals that persist across registry instantiations.
+//
+// OpenClaw caches plugin registries by workspaceDir. When an agent has a
+// per-agent workspace it receives a brand-new registry at request time, but
+// start() is only invoked once during gateway boot on the *first* registry.
+// All subsequent registries therefore never call start(), which means tools
+// appear registered but every call fails silently with "Tool not available".
+//
+// Keeping the pool and a descriptor cache at module scope lets us skip the
+// full service lifecycle for those later registries: we simply re-register
+// the already-connected tools straight into the new api instance.
+let globalPool: McpClientPool | null = null;
+let globalToolCache: ToolCacheEntry[] = [];
+
 export default function (api: any) {
   const config = parseConfig(api.pluginConfig);
 
   if (config.servers.length === 0) {
     console.log("[mcp-adapter] No servers configured");
+    return;
+  }
+
+  // Fast path: a pool is already running from a previous registry instantiation.
+  // Re-register every cached tool into this new registry and return early —
+  // no new connections, no service lifecycle.
+  if (globalPool && globalToolCache.length > 0) {
+    console.log(`[mcp-adapter] Re-registering ${globalToolCache.length} cached tools for new registry`);
+    for (const entry of globalToolCache) {
+      api.registerTool({
+        name: entry.toolName,
+        description: entry.description,
+        parameters: entry.parameters,
+        async execute(_id: string, params: unknown) {
+          const result = await globalPool!.callTool(entry.serverName, entry.originalName, params);
+          const text = result.content
+            ?.map((c: any) => c.text ?? c.data ?? "")
+            .join("\n") ?? "";
+          return {
+            content: [{ type: "text", text }],
+            isError: result.isError,
+          };
+        },
+      });
+    }
     return;
   }
 
@@ -16,6 +63,8 @@ export default function (api: any) {
     id: "mcp-adapter",
 
     async start() {
+      globalPool = pool;
+
       for (const server of config.servers) {
         try {
           console.log(`[mcp-adapter] Connecting to ${server.name}...`);
@@ -26,11 +75,13 @@ export default function (api: any) {
 
           for (const tool of tools) {
             const toolName = config.toolPrefix ? `${server.name}_${tool.name}` : tool.name;
+            const description = tool.description ?? `Tool from ${server.name}`;
+            const parameters = tool.inputSchema ?? { type: "object", properties: {} };
 
             api.registerTool({
               name: toolName,
-              description: tool.description ?? `Tool from ${server.name}`,
-              parameters: tool.inputSchema ?? { type: "object", properties: {} },
+              description,
+              parameters,
               async execute(_id: string, params: unknown) {
                 const result = await pool.callTool(server.name, tool.name, params);
                 const text = result.content
@@ -41,6 +92,16 @@ export default function (api: any) {
                   isError: result.isError,
                 };
               },
+            });
+
+            // Cache tool metadata so subsequent per-agent registry instances
+            // can re-register without going through the service lifecycle again.
+            globalToolCache.push({
+              toolName,
+              serverName: server.name,
+              originalName: tool.name,
+              description,
+              parameters,
             });
 
             console.log(`[mcp-adapter] Registered: ${toolName}`);
@@ -54,6 +115,8 @@ export default function (api: any) {
     async stop() {
       console.log("[mcp-adapter] Shutting down...");
       await pool.closeAll();
+      globalPool = null;
+      globalToolCache = [];
       console.log("[mcp-adapter] All connections closed");
     },
   });


### PR DESCRIPTION
## Problem

When an agent uses a per-agent workspace, OpenClaw creates a fresh plugin registry for each request (keyed by `workspaceDir`). The `start()` method — which connects to MCP servers and registers tools — is only called once during gateway boot on the **first** registry. All subsequent registries skip `start()` entirely.

The result: tools appear in the registry (they were registered on the first instance), but every call fails silently with **"Tool not available"** because the new registry has no `execute` handlers wired up.

## Root cause

`start()` is tied to the service lifecycle, which only runs once per gateway process. Per-agent registries are instantiated at request time and never go through that lifecycle.

## Fix

Introduce two module-level globals that persist across registry instantiations:

- **`globalPool: McpClientPool | null`** — the single shared connection pool, set at the start of `start()` and cleared in `stop()`
- **`globalToolCache: ToolCacheEntry[]`** — descriptors (toolName, serverName, originalName, description, parameters) for every registered tool, populated inside `start()` after each `api.registerTool()` call, and cleared in `stop()`

At the top of the default export function, after validating that servers are configured, we check:

```ts
if (globalPool && globalToolCache.length > 0) {
  // fast path: re-register all cached tools into this new registry
  for (const entry of globalToolCache) {
    api.registerTool({ ... executes via globalPool ... });
  }
  return; // skip service lifecycle entirely
}
```

This means subsequent per-agent registries get fully wired `execute` handlers pointing at the already-running pool, with zero new connections or lifecycle overhead.

## Behaviour

| Scenario | Before | After |
|---|---|---|
| First registry (gateway boot) | ✅ tools work | ✅ tools work (identical path) |
| Subsequent per-agent registries | ❌ calls fail silently | ✅ tools re-registered from cache |
| After `stop()` + restart | ✅ full reconnect | ✅ full reconnect (globals reset) |

## No breaking changes

First-registry behaviour is completely unchanged. Only subsequent per-agent registry instantiations take the new fast path.