### PR TITLE
fix: detect SSE stream disconnection errors for auto-reconnect

### DIFF
--- a/mcp-client.ts
+++ b/mcp-client.ts
@@ -25,6 +25,9 @@ export class McpClientPool {
       transport.onclose = () => this.markDisconnected(config.name);
     }
 
+    // Catch MCP-level errors for all transports (e.g. SSE disconnects inside mcp-remote)
+    client.onerror = () => this.markDisconnected(config.name);
+
     this.clients.set(config.name, { config, client, transport, connected: true });
     return client;
   }
@@ -80,7 +83,13 @@ export class McpClientPool {
 
   private isConnectionError(err: unknown): boolean {
     const msg = String(err);
-    return msg.includes("closed") || msg.includes("ECONNREFUSED") || msg.includes("EPIPE");
+    return (
+      msg.includes("closed") ||
+      msg.includes("ECONNREFUSED") ||
+      msg.includes("EPIPE") ||
+      msg.includes("terminated") ||
+      msg.includes("SSE stream disconnected")
+    );
   }
 
   getStatus(serverName: string) {


### PR DESCRIPTION
## Problem

When using `mcp-remote` to proxy remote HTTP/SSE-based MCP servers (e.g. PostHog, Jina AI), the remote server closes idle SSE connections after ~5 minutes. `mcp-remote` emits an error:

```
Error: SSE stream disconnected: TypeError: terminated
```

This error string was not recognized by `isConnectionError()`, so the auto-reconnect path in `callTool()` was never triggered. The connection appears live from the stdio perspective (the `mcp-remote` subprocess stays running) but subsequent tool calls silently fail until the gateway restarts.

## Root Cause

`isConnectionError()` only matched: `"closed"`, `"ECONNREFUSED"`, `"EPIPE"` — none of which appear in the mcp-remote SSE disconnection error string.

Additionally, `client.onerror` was only wired up for `StdioClientTransport` via transport-level callbacks. For servers that undergo internal SSE failures without crashing the subprocess, the connection never gets marked stale.

## Fix

1. **Add `"terminated"` and `"SSE stream disconnected"`** to the `isConnectionError()` patterns so reconnection fires on the next `callTool()` failure.

2. **Wire `client.onerror`** for all transport types (not just stdio), so MCP-level errors proactively mark the connection stale.

## Reproduction

- Configure any MCP server via `npx mcp-remote@latest <url>` where the remote uses HTTP/SSE transport
- Remote server: PostHog (`https://mcp.posthog.com/mcp`) or Jina AI (`https://mcp.jina.ai/v1`)
- Wait ~5 minutes for remote idle timeout
- Observe `SSE stream disconnected: TypeError: terminated` in logs
- Tool calls to that server then fail without triggering reconnect